### PR TITLE
[FIX] Failing `update-theme` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "setup-example": "git submodule add https://github.com/noesya/osuny-example",
     "server-example": "hugo server --config 'osuny-example/config/example/config.yaml'",
     "example": "yarn setup-example > /dev/null || yarn update && yarn server-example",
-    "update-theme": "cd themes/osuny-hugo-theme && git checkout main && git pull && cd ../.. && yarn upgrade"
+    "update-theme": "cd themes/osuny-hugo-theme-aaa && git checkout main && git pull && cd ../.. && yarn upgrade"
   }
 }


### PR DESCRIPTION
Lorsque le script `update-theme` est executé avec un client npm, la commande retourne une erreur.

```bash
➜  bordeauxmontaigne-lesveteransduweb-1 git:(main) yarn update-theme
yarn run v1.22.17
$ cd themes/osuny-hugo-theme && git checkout main && git pull && cd ../.. && yarn upgrade
/bin/sh: line 0: cd: themes/osuny-hugo-theme: No such file or directory
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command
```

L'erreur est provoquée par une erreur d'écriture du thème `osuny-hugo-theme-aaa`